### PR TITLE
Create three reusable utility functions for services layer 

### DIFF
--- a/src/utilities/ServiceOperationResult.ts
+++ b/src/utilities/ServiceOperationResult.ts
@@ -1,0 +1,25 @@
+import type { ServiceOperationResultType as SORT } from "../types/response";
+
+export default class ServiceOperationResult {
+  public static success(
+    result?: SORT["result"],
+    message?: SORT["message"]
+  ): SORT {
+    return {
+      result,
+      isSuccess: true,
+      message,
+    };
+  }
+
+  public static failure(
+    message: SORT["message"],
+    result: SORT["result"] = null
+  ): SORT {
+    return {
+      result,
+      isSuccess: false,
+      message,
+    };
+  }
+}

--- a/src/utilities/createTransactionSession.ts
+++ b/src/utilities/createTransactionSession.ts
@@ -1,0 +1,8 @@
+import type { ClientSession } from "mongoose";
+import { startSession } from "mongoose";
+
+export default async function createTransactionSession(): Promise<ClientSession> {
+  const session = await startSession();
+  session.startTransaction();
+  return session;
+}

--- a/src/utilities/parsePaginationModel.ts
+++ b/src/utilities/parsePaginationModel.ts
@@ -1,0 +1,11 @@
+import type { PaginationModel } from "../types/response";
+
+const defaultPageSize = 5;
+const defaultPageNumber = 1;
+
+export default function parsePaginationModel(model: PaginationModel) {
+  const limit = model?.pageSize || defaultPageSize;
+  const skip = ((model?.page || defaultPageNumber) - 1) * limit;
+
+  return { limit, skip };
+}


### PR DESCRIPTION
Create these three reusable utility functions for services layer 👇 

* `createTransactionSession` utility function to provide a shortcut for creating a transaction 
session for multi documents mutations.

* `ServiceOperationResult` utility class that has two methods provide shortcuts for the standard 
results of services operations (`ServiceOperationResultType`); `success` method provides a 
shortcut for a successful operation, And `failure` method provides a shortcut for a failed operation.

* `parsePaginationModel` utility function which is a simple function parses the given input as parameter 
and convert it to `limit` and `skip` values that are used to specify which page to bring in mongodb queries.

