### PR TITLE
Build recent activities service (`ActivitiesService` class)

### DIFF
--- a/src/services/activities/index.ts
+++ b/src/services/activities/index.ts
@@ -1,0 +1,20 @@
+import unregisterInstructionActivity_service from "./unregisterInstructionActivity_service";
+import unregisterDatasetActivity_service from "./unregisterDatasetActivity_service";
+import registerInstructionActivity_service from "./registerInstructionActivity_service";
+import registerDatasetActivity_service from "./registerDatasetActivity_service";
+
+class ActivitiesService {
+  constructor() {}
+
+  registerDatasetActivity = registerDatasetActivity_service;
+
+  registerInstructionActivity = registerInstructionActivity_service;
+
+  unregisterDatasetActivity = unregisterDatasetActivity_service;
+
+  unregisterInstructionActivity = unregisterInstructionActivity_service;
+}
+
+const activitiesService = new ActivitiesService();
+
+export default activitiesService;

--- a/src/services/activities/registerActivity_service.ts
+++ b/src/services/activities/registerActivity_service.ts
@@ -1,0 +1,28 @@
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import RecentActivitiesModel from "../../models/RecentActivitiesModel";
+import type { Activity, ActivityResource } from "../../types/activities";
+import type { ServiceOperationResultType } from "../../types/response";
+
+export default async function registerActivity_service(
+  resourceName: ActivityResource,
+  activity: Activity
+): Promise<ServiceOperationResultType> {
+  const updateQuery = [
+    {
+      $set: {
+        [`recentActivitiesOf${resourceName}`]: {
+          $concatArrays: [
+            [activity],
+            { $slice: [`$recentActivitiesOf${resourceName}`, 4] },
+          ],
+        },
+      },
+    },
+  ];
+  const result = await RecentActivitiesModel.updateOne({}, updateQuery);
+  if (result.modifiedCount) {
+    return ServiceOperationResult.success(true);
+  }
+
+  return ServiceOperationResult.failure("Activity registration failed", false);
+}

--- a/src/services/activities/registerDatasetActivity_service.ts
+++ b/src/services/activities/registerDatasetActivity_service.ts
@@ -1,0 +1,19 @@
+import type { Types } from "mongoose";
+import type { ActivitiesTypes } from "../../types/activities";
+import registerActivity_service from "./registerActivity_service";
+
+export default async function registerDatasetActivity_service(
+  datasetId: Types.ObjectId,
+  activityDate: Date,
+  activity: ActivitiesTypes
+) {
+  try {
+    await registerActivity_service("Datasets", {
+      datasetId,
+      activityDate,
+      activity,
+    });
+  } catch {
+    // logging system
+  }
+}

--- a/src/services/activities/registerInstructionActivity_service.ts
+++ b/src/services/activities/registerInstructionActivity_service.ts
@@ -1,0 +1,21 @@
+import type { Types } from "mongoose";
+import type { ActivitiesTypes } from "../../types/activities";
+import registerActivity_service from "./registerActivity_service";
+
+export default async function registerInstructionActivity_service(
+  datasetId: Types.ObjectId,
+  instructionId: Types.ObjectId,
+  activityDate: Date,
+  activity: ActivitiesTypes
+) {
+  try {
+    await registerActivity_service("Instructions", {
+      instructionId,
+      datasetId,
+      activityDate,
+      activity,
+    });
+  } catch {
+    // logging system
+  }
+}

--- a/src/services/activities/unregisterActivity_service.ts
+++ b/src/services/activities/unregisterActivity_service.ts
@@ -1,0 +1,28 @@
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import RecentActivitiesModel from "../../models/RecentActivitiesModel";
+import type { ActivityFilter, ActivityResource } from "../../types/activities";
+import type { ServiceOperationResultType } from "../../types/response";
+
+export default async function unregisterActivities_service(
+  resourceName: ActivityResource,
+  targetFilter: ActivityFilter
+): Promise<ServiceOperationResultType> {
+  const updateQuery = {
+    $pull: {
+      [`recentActivitiesOf${resourceName}`]: targetFilter,
+    },
+  };
+
+  if (resourceName === "Datasets") {
+    updateQuery.$pull.recentActivitiesOfInstructions = {
+      datasetId: targetFilter.datasetId,
+    };
+  }
+
+  const result = await RecentActivitiesModel.updateOne({}, updateQuery);
+  if (result.modifiedCount) {
+    return ServiceOperationResult.success(true);
+  }
+
+  return ServiceOperationResult.failure("Activity registration failed", false);
+}

--- a/src/services/activities/unregisterDatasetActivity_service.ts
+++ b/src/services/activities/unregisterDatasetActivity_service.ts
@@ -1,0 +1,15 @@
+import { Types } from "mongoose";
+import type { Dataset } from "../../types/datasets";
+import unregisterActivities_service from "./unregisterActivity_service";
+
+export default async function unregisterDatasetActivity_service(
+  datasetId: Dataset["id"]
+) {
+  try {
+    await unregisterActivities_service("Datasets", {
+      datasetId: new Types.ObjectId(datasetId),
+    });
+  } catch {
+    // logging system
+  }
+}

--- a/src/services/activities/unregisterInstructionActivity_service.ts
+++ b/src/services/activities/unregisterInstructionActivity_service.ts
@@ -1,0 +1,18 @@
+import { Types } from "mongoose";
+import type { Dataset } from "../../types/datasets";
+import type { Instruction } from "../../types/instructions";
+import unregisterActivities_service from "./unregisterActivity_service";
+
+export default async function unregisterInstructionActivity_service(
+  datasetId: Dataset["id"],
+  instructionId: Instruction["id"]
+) {
+  try {
+    await unregisterActivities_service("Instructions", {
+      instructionId: new Types.ObjectId(instructionId),
+      datasetId: new Types.ObjectId(datasetId),
+    });
+  } catch {
+    // logging system
+  }
+}


### PR DESCRIPTION
Build recent activities service class (`ActivitiesService`) for dealing with recent activities data 
in one centralized place (`src/services/activities`) directory, 

`ActivitiesService` class represents the business layer of dealing with recent activities data 
in the application, And this class provides for now four methods: 

* `registerDatasetActivity` which is a shorthand for registering datasets activities.

* `registerInstructionActivity` which is a shorthand for registering instruction activities.

* `unregisterDatasetActivity` which is a shorthand for unregistering datasets activities.

* `unregisterInstructionActivity` which is a shorthand for unregistering instruction activities.

These methods use `registerActivity_service` and `unregisterActivity_service` service functions 
to do their tasks, these two functions are which have the actual logic of registering and 
unregistering activities.
