### PR TITLE
Create datasets service class `DatasetsService`

### DIFF
--- a/src/services/datasets/createDataset_service.ts
+++ b/src/services/datasets/createDataset_service.ts
@@ -1,0 +1,44 @@
+import mongoose from "mongoose";
+import createTransactionSession from "../../utilities/createTransactionSession";
+import DatasetModel from "../../models/DatasetModel";
+import type { DatasetInput } from "../../types/datasets";
+import type { ServiceOperationResultType } from "../../types/response";
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import activitiesService from "../activities";
+
+export default async function createDataset_service(
+  dataset: DatasetInput
+): Promise<ServiceOperationResultType> {
+  const session = await createTransactionSession();
+
+  const newDataset = new DatasetModel(dataset);
+  const datasetAdded = await newDataset
+    .save({ session })
+    .then(() => true)
+    .catch(() => false);
+
+  if (datasetAdded) {
+    const collectionCreated = await mongoose.connection
+      .createCollection(newDataset.id, { session })
+      .then(() => true)
+      .catch(() => false);
+
+    if (collectionCreated) {
+      await session.commitTransaction();
+      activitiesService.registerDatasetActivity(
+        newDataset._id,
+        newDataset.createdAt,
+        "New Resource"
+      );
+      return ServiceOperationResult.success(
+        newDataset,
+        `"${dataset.name}" dataset created successfuly`
+      );
+    }
+  }
+
+  await session.abortTransaction();
+  return ServiceOperationResult.failure(
+    `"${newDataset.name}" dataset creation failed`
+  );
+}

--- a/src/services/datasets/deleteDataset_service.ts
+++ b/src/services/datasets/deleteDataset_service.ts
@@ -1,0 +1,43 @@
+import mongoose from "mongoose";
+import DatasetModel from "../../models/DatasetModel";
+import type { Dataset } from "../../types/datasets";
+import createTransactionSession from "../../utilities/createTransactionSession";
+import type { ServiceOperationResultType } from "../../types/response";
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import activitiesService from "../activities";
+
+export default async function deleteDataset_service(
+  datasetId: Dataset["id"]
+): Promise<ServiceOperationResultType> {
+  const session = await createTransactionSession();
+  const dataset = await DatasetModel.findOneAndDelete(
+    { _id: datasetId },
+    { session, projection: ["name"] }
+  );
+
+  if (dataset) {
+    const collectionDroped = await mongoose.connection
+      .dropCollection(datasetId)
+      .then(() => true)
+      .catch(() => false);
+
+    if (collectionDroped) {
+      await session.commitTransaction();
+      activitiesService.unregisterDatasetActivity(dataset.id);
+      return ServiceOperationResult.success(
+        true,
+        `"${dataset?.name}" dataset was deleted successfully`
+      );
+    } else {
+      session.abortTransaction();
+      return ServiceOperationResult.failure(
+        `Deleting "${dataset?.name}" dataset failed`
+      );
+    }
+  } else {
+    await session.abortTransaction();
+    return ServiceOperationResult.failure(
+      `There is no dataset with "${datasetId}" id`
+    );
+  }
+}

--- a/src/services/datasets/getDatasetById_service.ts
+++ b/src/services/datasets/getDatasetById_service.ts
@@ -1,0 +1,17 @@
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import DatasetModel from "../../models/DatasetModel";
+import type { Dataset } from "../../types/datasets";
+import type { ServiceOperationResultType } from "../../types/response";
+
+export default async function getDatasetsById_service(
+  id: Dataset["id"]
+): Promise<ServiceOperationResultType<Dataset>> {
+  const result = await DatasetModel.findById(id);
+  if (result) {
+    return ServiceOperationResult.success(result);
+  } else {
+    return ServiceOperationResult.failure(
+      `There is no dataset with "${id}" id`
+    );
+  }
+}

--- a/src/services/datasets/getDatasets_service.ts
+++ b/src/services/datasets/getDatasets_service.ts
@@ -1,0 +1,11 @@
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import DatasetModel from "../../models/DatasetModel";
+import type { ServiceOperationResultType } from "../../types/response";
+
+export default async function getDatasets_service(): Promise<ServiceOperationResultType> {
+  const result = await DatasetModel.find({});
+  return ServiceOperationResult.success(
+    result,
+    result.length ? undefined : "There is no datasets yet"
+  );
+}

--- a/src/services/datasets/incrementInstructionsCount_service.ts
+++ b/src/services/datasets/incrementInstructionsCount_service.ts
@@ -1,0 +1,31 @@
+import type { ClientSession } from "mongoose";
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import DatasetModel from "../../models/DatasetModel";
+import type { Dataset } from "../../types/datasets";
+import type { ServiceOperationResultType } from "../../types/response";
+
+export default async function incrementInstructionsCount_service(
+  id: Dataset["id"],
+  incrementValue: number = 1,
+  session?: ClientSession
+): Promise<ServiceOperationResultType> {
+  const result = await DatasetModel.updateOne(
+    { _id: id },
+    { $inc: { instructionsCount: incrementValue } },
+    { session }
+  );
+  if (result.acknowledged && result.modifiedCount) {
+    return ServiceOperationResult.success(
+      true,
+      "Instructions count incremented successfully"
+    );
+  } else if (!result.matchedCount) {
+    return ServiceOperationResult.failure(
+      `There is no dataset with "${id}" id`
+    );
+  } else {
+    return ServiceOperationResult.failure(
+      "Faild to increment instructions count"
+    );
+  }
+}

--- a/src/services/datasets/index.ts
+++ b/src/services/datasets/index.ts
@@ -1,0 +1,26 @@
+import createDataset_service from "./createDataset_service";
+import getDatasets_service from "./getDatasets_service";
+import deleteDataset_service from "./deleteDataset_service";
+import updateDataset_service from "./updateDataset_service";
+import getDatasetsById_service from "./getDatasetById_service";
+import incrementInstructionsCount_service from "./incrementInstructionsCount_service";
+
+class DatasetsService {
+  constructor() {}
+
+  createDataset = createDataset_service;
+
+  getDatasetsById = getDatasetsById_service;
+
+  getDatasets = getDatasets_service;
+
+  updateDataset = updateDataset_service;
+
+  deleteDataset = deleteDataset_service;
+
+  incrementInstructionsCount = incrementInstructionsCount_service;
+}
+
+const datasetsService = new DatasetsService();
+
+export default datasetsService;

--- a/src/services/datasets/updateDataset_service.ts
+++ b/src/services/datasets/updateDataset_service.ts
@@ -1,0 +1,29 @@
+import DatasetModel from "../../models/DatasetModel";
+import type { Dataset, UpdateDatasetInput } from "../../types/datasets";
+import type { ServiceOperationResultType } from "../../types/response";
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import activitiesService from "../activities";
+
+export default async function updateDataset_service(
+  datasetId: Dataset["id"],
+  updateData: UpdateDatasetInput
+): Promise<ServiceOperationResultType> {
+  const filter = { _id: datasetId };
+  const dataset = await DatasetModel.findOneAndUpdate(filter, updateData, {
+    new: true,
+  });
+
+  if (dataset) {
+    activitiesService.registerDatasetActivity(
+      dataset._id,
+      dataset.updatedAt,
+      "Modification"
+    );
+    return ServiceOperationResult.success(
+      updateData,
+      `The dataset updated successfully`
+    );
+  } else {
+    return ServiceOperationResult.failure(`Dataset not found to update`);
+  }
+}


### PR DESCRIPTION
Create datasets service class `DatasetsService` that represents the business layer of dealing 
with datasets in the application or the server, It provides for now six service methods for 
dealing with datasets like creating, deleting and updating, these six methods are:

* `createDataset` service method for creating new datasets.
* getDatasetsById` service method for getting a specific datasets.
* `getDatasets` service method  for getting all datasets.
* `updateDataset` service method for updating a specific datasets.
* `deleteDataset` service method for deleting a specific datasets.
* `incrementInstructionsCount` service method for incrementing dataset's instructions count.
