### PR TITLE
Don't create a new collection if the targeted one isn't exists

### DIFF
--- a/src/models/InstructionModel.ts
+++ b/src/models/InstructionModel.ts
@@ -1,5 +1,6 @@
-import { Schema, Types, model } from "mongoose";
+import mongoose, { Schema, Types, model } from "mongoose";
 import type { Dataset } from "../types/datasets";
+import ServiceOperationResult from "../utilities/ServiceOperationResult";
 
 const InstructionSchema = new Schema(
   {
@@ -25,6 +26,18 @@ const InstructionSchema = new Schema(
   }
 );
 
-export default function InstructionModel(datasetId: Dataset["id"]) {
-  return model(datasetId, InstructionSchema, datasetId);
+export default async function InstructionModel(datasetId: Dataset["id"]) {
+  const collectionExists = (await mongoose.connection.listCollections()).some(
+    (collection) => collection.name === datasetId
+  );
+
+  if (collectionExists) {
+    return { Model: model(datasetId, InstructionSchema, datasetId) };
+  }
+
+  return {
+    failure: ServiceOperationResult.failure(
+      "There is no dataset with this id: " + datasetId
+    ),
+  };
 }


### PR DESCRIPTION
Convert `InstructionModel` function to async function and add to it an asynchronous 
check task to know if the targeted collection to create a model for is exists or no, 
if is exists the function creates and returns a model for it, otherwise will return failure 
result using `ServiceOperationResult` class.