### PR TITLE
Create requests inputs validation middlewares

### DIFF
--- a/src/middlewares/addInstructionInputValidator.ts
+++ b/src/middlewares/addInstructionInputValidator.ts
@@ -1,0 +1,23 @@
+import ErrorResponse from "../utilities/ErrorResponse";
+import type { AddInstructionInput } from "../types/instructions";
+import type { Req } from "../types/request";
+import type { ValidationError } from "../types/validation";
+import InstructionSchemaRules from "../validation/InstructionSchemaRules";
+import RequiredObjectIdRule from "../validation/RequiredObjectIdRule";
+import validationSchema from "../validation/validationSchema";
+
+const instructionInput = validationSchema<AddInstructionInput>({
+  systemMessage: InstructionSchemaRules().systemMessage,
+  question: InstructionSchemaRules().answer.required(),
+  answer: InstructionSchemaRules().answer.required(),
+  datasetId: RequiredObjectIdRule(),
+});
+
+export default function addInstructionInputValidator(request: Req) {
+  try {
+    request.json = instructionInput.validate(request.json);
+  } catch (e: any) {
+    const validationErrors = e.errors as ValidationError["errors"];
+    return ErrorResponse({ validationErrors }, 403);
+  }
+}

--- a/src/middlewares/createDatasetInputValidator.ts
+++ b/src/middlewares/createDatasetInputValidator.ts
@@ -1,0 +1,20 @@
+import ErrorResponse from "../utilities/ErrorResponse";
+import type { DatasetInput } from "../types/datasets";
+import type { Req } from "../types/request";
+import type { ValidationError } from "../types/validation";
+import DatasetSchemaRule from "../validation/DatasetSchemaRule";
+import validationSchema from "../validation/validationSchema";
+
+const datasetInput = validationSchema<DatasetInput>({
+  name: DatasetSchemaRule().name.required(),
+  description: DatasetSchemaRule().description.required(),
+});
+
+export default function createDatasetInputValidator(request: Req) {
+  try {
+    request.json = datasetInput.validate(request.json);
+  } catch (e: any) {
+    const validationErrors = e.errors as ValidationError;
+    return ErrorResponse({ validationErrors }, 403);
+  }
+}

--- a/src/middlewares/createDatasetInputValidator.ts
+++ b/src/middlewares/createDatasetInputValidator.ts
@@ -14,7 +14,7 @@ export default function createDatasetInputValidator(request: Req) {
   try {
     request.json = datasetInput.validate(request.json);
   } catch (e: any) {
-    const validationErrors = e.errors as ValidationError;
+    const validationErrors = e.errors as ValidationError["errors"];
     return ErrorResponse({ validationErrors }, 403);
   }
 }

--- a/src/middlewares/deleteDatasetInputValidator.ts
+++ b/src/middlewares/deleteDatasetInputValidator.ts
@@ -1,0 +1,25 @@
+import ErrorResponse from "../utilities/ErrorResponse";
+import type { Req } from "../types/request";
+import type { ValidationError } from "../types/validation";
+import RequiredObjectIdRule from "../validation/RequiredObjectIdRule";
+import validationSchema from "../validation/validationSchema";
+import type { Dataset } from "../types/datasets";
+
+const deleteDatasetInputSchema = validationSchema<{
+  datasetId: Dataset["id"];
+}>({
+  datasetId: RequiredObjectIdRule(),
+});
+
+export default function deleteDatasetInputValidator(request: Req) {
+  try {
+    const { datasetId } = deleteDatasetInputSchema.validate({
+      datasetId: request.params.datasetId,
+    });
+
+    request.params.datasetId = datasetId;
+  } catch (e: any) {
+    const validationErrors = e.errors as ValidationError["errors"];
+    return ErrorResponse({ validationErrors }, 403);
+  }
+}

--- a/src/middlewares/deleteInstructionInputValidator.ts
+++ b/src/middlewares/deleteInstructionInputValidator.ts
@@ -1,0 +1,29 @@
+import ErrorResponse from "../utilities/ErrorResponse";
+import type { Req } from "../types/request";
+import type { ValidationError } from "../types/validation";
+import validationSchema from "../validation/validationSchema";
+import RequiredObjectIdRule from "../validation/RequiredObjectIdRule";
+import type { Dataset } from "../types/datasets";
+import type { Instruction } from "../types/instructions";
+
+const deleteInstructionInputSchema = validationSchema<{
+  datasetId: Dataset["id"];
+  instructionId: Instruction["id"];
+}>({
+  datasetId: RequiredObjectIdRule(),
+  instructionId: RequiredObjectIdRule(),
+});
+
+export default function deleteInstructionInputValidator(request: Req) {
+  try {
+    const { datasetId, instructionId } = deleteInstructionInputSchema.validate({
+      datasetId: request.search.datasetId,
+      instructionId: request.search.instructionId,
+    });
+    request.json.instructionId = instructionId;
+    request.json.datasetId = datasetId;
+  } catch (e: any) {
+    const validationErrors = e.errors as ValidationError["errors"];
+    return ErrorResponse({ validationErrors }, 403);
+  }
+}

--- a/src/middlewares/updateDatasetInputValidator.ts
+++ b/src/middlewares/updateDatasetInputValidator.ts
@@ -1,0 +1,28 @@
+import ErrorResponse from "../utilities/ErrorResponse";
+import type { Dataset, UpdateDatasetInput } from "../types/datasets";
+import type { Req } from "../types/request";
+import type { ValidationError } from "../types/validation";
+import validationSchema from "../validation/validationSchema";
+import DatasetSchemaRule from "../validation/DatasetSchemaRule";
+import RequiredObjectIdRule from "../validation/RequiredObjectIdRule";
+
+const updateDatasetInputSchema = validationSchema<
+  UpdateDatasetInput & { datasetId: Dataset["id"] }
+>({
+  datasetId: RequiredObjectIdRule(),
+  ...DatasetSchemaRule(),
+});
+
+export default function updateDatasetInputValidator(request: Req) {
+  try {
+    const { datasetId, ...updateData } = updateDatasetInputSchema.validate({
+      ...request.json,
+      datasetId: request.params.datasetId,
+    });
+    request.json = updateData;
+    request.json.datasetId = datasetId;
+  } catch (e: any) {
+    const validationErrors = e.errors as ValidationError;
+    return ErrorResponse({ validationErrors }, 403);
+  }
+}

--- a/src/middlewares/updateDatasetInputValidator.ts
+++ b/src/middlewares/updateDatasetInputValidator.ts
@@ -22,7 +22,7 @@ export default function updateDatasetInputValidator(request: Req) {
     request.json = updateData;
     request.json.datasetId = datasetId;
   } catch (e: any) {
-    const validationErrors = e.errors as ValidationError;
+    const validationErrors = e.errors as ValidationError["errors"];
     return ErrorResponse({ validationErrors }, 403);
   }
 }

--- a/src/middlewares/updateInstructionInputValidator.ts
+++ b/src/middlewares/updateInstructionInputValidator.ts
@@ -1,0 +1,38 @@
+import ErrorResponse from "../utilities/ErrorResponse";
+import type { Req } from "../types/request";
+import type { ValidationError } from "../types/validation";
+import validationSchema from "../validation/validationSchema";
+import RequiredObjectIdRule from "../validation/RequiredObjectIdRule";
+import type { Dataset } from "../types/datasets";
+import type {
+  Instruction,
+  UpdateInstructionInput,
+} from "../types/instructions";
+import InstructionSchemaRules from "../validation/InstructionSchemaRules";
+
+const updateInstructionInputSchema = validationSchema<
+  {
+    datasetId: Dataset["id"];
+    instructionId: Instruction["id"];
+  } & UpdateInstructionInput
+>({
+  datasetId: RequiredObjectIdRule(),
+  instructionId: RequiredObjectIdRule(),
+  ...InstructionSchemaRules(),
+});
+
+export default function updateInstructionInputValidator(request: Req) {
+  try {
+    const { datasetId, instructionId, ...updateData } =
+      updateInstructionInputSchema.validate({
+        datasetId: request.search.datasetId,
+        instructionId: request.search.instructionId,
+        ...request.json,
+      });
+
+    request.json = updateData;
+  } catch (e: any) {
+    const validationErrors = e.errors as ValidationError;
+    return ErrorResponse({ validationErrors }, 403);
+  }
+}

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -1,5 +1,12 @@
-export type ValidationError = {
+export type ValidationErrorDetails = {
   filed: string;
   message: string;
   value: any;
 };
+
+export class ValidationError extends Error {
+  constructor(public errors: ValidationErrorDetails[], message?: string) {
+    super(message || "Validation Error !");
+    this.name = "ValidationError";
+  }
+}

--- a/src/validation/validateObject.ts
+++ b/src/validation/validateObject.ts
@@ -1,4 +1,7 @@
-import type { ValidationError } from "../types/validation";
+import {
+  ValidationError,
+  type ValidationErrorDetails,
+} from "../types/validation";
 import type { NumberValidator } from "./numberValidator";
 import type { StringValidator } from "./stringValidator";
 
@@ -6,7 +9,7 @@ export default function validateObject<ValidInputType>(
   schema: Record<string, StringValidator | NumberValidator>,
   object: Record<string, any>
 ) {
-  const errors: ValidationError[] = [];
+  const errors: ValidationErrorDetails[] = [];
   const validObject: typeof object = {};
   for (const key in schema) {
     const result = schema[key].validate(object[key], key);
@@ -24,8 +27,8 @@ export default function validateObject<ValidInputType>(
   }
 
   if (errors.length) {
-    const error = new Error();
-    throw Object.assign(error, { errors });
+    const error = new ValidationError(errors);
+    throw error;
   }
 
   return validObject as ValidInputType;


### PR DESCRIPTION
Create `src/middlewares` directory and inside this directory create six validation middlewares 
for validation the requests inputs the make mutations in the database, 

These are the six validation middlewares :point_down:

* `createDatasetInputValidator` middleware for validating the inputs of creating new datasets requests.
* `updateDatasetInputValidator` middleware for validating the inputs of updating datasets requests.
* `deleteDatasetInputValidator` middleware for validating the inputs of deleting datasets requests.
* `addInstructionInputValidator` middleware for validating the inputs of adding new instruction to datasets requests.
* `updateInstructionInputValidator` middleware for validating the inputs of updating instruction in datasets requests.
* `deleteInstructionInputValidator` middleware for validating the inputs of deleting instruction from datasets requests.
