### PR TITLE
Remove an unnecessary code from datasets controllers

### DIFF
--- a/src/controllers/datasets/createDataset_controller.ts
+++ b/src/controllers/datasets/createDataset_controller.ts
@@ -15,7 +15,7 @@ export default async function createDataset_controller(
     if (isSuccess) {
       return SuccessResponse(result, message);
     } else {
-      return ErrorResponse(message || "Dataset creation failed", 400);
+      return ErrorResponse(message || "Dataset creation failed");
     }
   } catch {
     return InternalServerErrorResponse();

--- a/src/controllers/datasets/deleteDataset_controller.ts
+++ b/src/controllers/datasets/deleteDataset_controller.ts
@@ -15,7 +15,7 @@ export default async function deleteDataset_controller(
     if (isSuccess) {
       return SuccessResponse(result, message);
     } else {
-      return ErrorResponse(message || "Dataset deletion failed", 400);
+      return ErrorResponse(message || "Dataset deletion failed");
     }
   } catch {
     return InternalServerErrorResponse();

--- a/src/controllers/datasets/updateDataset_controller.ts
+++ b/src/controllers/datasets/updateDataset_controller.ts
@@ -16,7 +16,7 @@ export default async function updateDataset_controller(
     if (isSuccess) {
       return SuccessResponse(result, message);
     } else {
-      return ErrorResponse(message || "Dataset creation failed", 400);
+      return ErrorResponse(message || "Dataset creation failed");
     }
   } catch {
     return InternalServerErrorResponse();


### PR DESCRIPTION
Remove 400 status code from `ErrorResponse` function because this function by default 
returns a response with 400 status code.