### PR TITLE
Fixing a bug and refactoring in `src/models/RecentActivitiesModel.ts` file

### DIFF
--- a/src/models/RecentActivitiesModel.ts
+++ b/src/models/RecentActivitiesModel.ts
@@ -1,7 +1,7 @@
 import { Schema, Types, model } from "mongoose";
 
 const SharedSchema = {
-  datasetsId: {
+  datasetId: {
     type: Types.ObjectId,
     required: true,
   },

--- a/src/models/RecentActivitiesModel.ts
+++ b/src/models/RecentActivitiesModel.ts
@@ -1,6 +1,6 @@
 import { Schema, Types, model } from "mongoose";
 
-const SharedSchema = {
+const ActivitySchema = {
   datasetId: {
     type: Types.ObjectId,
     required: true,
@@ -20,7 +20,7 @@ const RecentActivitiesSchema = new Schema(
     recentActivitiesOfInstructions: {
       type: [
         {
-          ...SharedSchema,
+          ...ActivitySchema,
           instructionId: {
             type: Types.ObjectId,
             required: true,
@@ -31,13 +31,13 @@ const RecentActivitiesSchema = new Schema(
       required: true,
     },
     recentActivitiesOfDatasets: {
-      type: [SharedSchema],
+      type: [ActivitySchema],
       default: [],
       required: true,
     },
   },
   {
-    timestamps: true,
+    timestamps: false,
     versionKey: false,
   }
 );


### PR DESCRIPTION
* Correct the name of dataset id property in the recent activities schema in `src/models/RecentActivitiesModel.ts` 
file by renaming the property from `datasetsId` to datasetId`.

* Rename `SharedSchema` to `ActivitySchema`.

* Set `timestamps` option of `RecentActivitiesSchema` (which represent the only document in "recent-activities" collection) 
to false, to prevent `mongoose` from creating timestamps fields for recent activities document because these fields 
are not mater for this document and will not be used.