### PR TITLE
Build Aplication's API routes registerers

### DIFF
--- a/src/routes/datasetsRoutes.ts
+++ b/src/routes/datasetsRoutes.ts
@@ -1,0 +1,29 @@
+import datasetsController from "../controllers/datasets";
+import type { RouterType } from "../router/Router";
+import createDatasetInputValidator from "../middlewares/createDatasetInputValidator";
+import deleteDatasetInputValidator from "../middlewares/deleteDatasetInputValidator";
+import updateDatasetInputValidator from "../middlewares/updateDatasetInputValidator";
+
+export default function datasetsRoutesRegisterer(router: RouterType): void {
+  const baseRoute = "/datasets";
+
+  router.GET(baseRoute, datasetsController.getDatasets);
+
+  router.POST(
+    baseRoute,
+    createDatasetInputValidator,
+    datasetsController.createDataset
+  );
+
+  router.DELETE(
+    `${baseRoute}/:datasetId`,
+    deleteDatasetInputValidator,
+    datasetsController.deleteDataset
+  );
+
+  router.PATCH(
+    `${baseRoute}/:datasetId`,
+    updateDatasetInputValidator,
+    datasetsController.updateDataset
+  );
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,8 @@
+import type { RouterType } from "../router/Router";
+import datasetsRoutesRegisterer from "./datasetsRoutes";
+import instructionsRoutesRegisterer from "./instructionsRoutes";
+
+export default function routesRegistering(router: RouterType) {
+  datasetsRoutesRegisterer(router);
+  instructionsRoutesRegisterer(router);
+}

--- a/src/routes/instructionsRoutes.ts
+++ b/src/routes/instructionsRoutes.ts
@@ -1,0 +1,29 @@
+import instructionsController from "../controllers/instructions";
+import type { RouterType } from "../router/Router";
+import addInstructionInputValidator from "../middlewares/addInstructionInputValidator";
+import deleteInstructionInputValidator from "../middlewares/deleteInstructionInputValidator";
+import updateInstructionInputValidator from "../middlewares/updateInstructionInputValidator";
+
+export default function instructionsRoutesRegisterer(router: RouterType): void {
+  const baseRoute = "/instructions";
+
+  router.GET(baseRoute, instructionsController.getInstructions);
+
+  router.POST(
+    baseRoute,
+    addInstructionInputValidator,
+    instructionsController.addInstruction
+  );
+
+  router.DELETE(
+    baseRoute,
+    deleteInstructionInputValidator,
+    instructionsController.deleteInstruction
+  );
+
+  router.PATCH(
+    baseRoute,
+    updateInstructionInputValidator,
+    instructionsController.updateInstruction
+  );
+}


### PR DESCRIPTION
Create `src/routes/index.ts` file and create in this
file `routesRegistering` function that collects all routes registerers in one place and takes the router 
as parameter and passes it to the routes registerers inside it.

The `routesRegistering` function contains for now two routes registerers: 

* `datasetsRoutesRegisterer` which registers the endpoints of dealing with datasets in application's API.

* `instructionsRoutesRegisterer` which registers the endpoints of dealing with datasets instructions in 
application's API.

The registration process is to call one of the HTTP methods functions of the router and pass to it the route 
path as first parameter and then a list of route handlers functions like validation middlewares and controllers 
to handle the requests on this route or endpoint.
**Note:** the last route handler must be a controller to
take the request to the service that should serve the
request.