### PR TITLE
Add getting instructions by ids service method to `InstructionsService` class

### DIFF
--- a/src/services/instructions/getInstructionsByIds_service.ts
+++ b/src/services/instructions/getInstructionsByIds_service.ts
@@ -1,0 +1,28 @@
+import ServiceOperationResult from "../../utilities/ServiceOperationResult";
+import InstructionModel from "../../models/InstructionModel";
+import type { Dataset } from "../../types/datasets";
+import type { Instruction } from "../../types/instructions";
+import type { ServiceOperationResultType } from "../../types/response";
+import type { Types } from "mongoose";
+
+export default async function getInstructionsByIds_service(
+  datasetId: Dataset["id"],
+  ids: Instruction["id"][] | Types.ObjectId[],
+  options?: { projection?: string[] | Record<string, boolean | number> }
+): Promise<ServiceOperationResultType<Instruction[]>> {
+  const { Model, failure } = await InstructionModel(datasetId);
+
+  if (Model) {
+    const result = await Model.find<Instruction>(
+      { _id: { $in: ids } },
+      options?.projection
+    );
+
+    return ServiceOperationResult.success(
+      result,
+      !result.length ? "No instructions in this dataset" : undefined
+    );
+  } else {
+    return failure;
+  }
+}

--- a/src/services/instructions/index.ts
+++ b/src/services/instructions/index.ts
@@ -1,5 +1,6 @@
 import addInstruction_service from "./addInstruction_service";
 import getInstructions_service from "./getInstructions_service";
+import getInstructionsByIds_service from "./getInstructionsByIds_service";
 import deleteInstruction_service from "./deleteInstruction_service";
 import updateInstruction_service from "./updateInstruction_service";
 
@@ -9,6 +10,8 @@ class InstructionsService {
   addInstruction = addInstruction_service;
 
   getInstructions = getInstructions_service;
+
+  getInstructionsByIds = getInstructionsByIds_service;
 
   updateInstruction = updateInstruction_service;
 


### PR DESCRIPTION
Create `getInstructionsByIds_service` service function to provide a way to get a collection of instructions 
in a specific datasets by passing the dataset id and an array of instructions ids to bring them from the db.

And add this service function as `getInstructionsByIds` method to `InstructionsService` class.