### PR TITLE
Make recent activities service returns the full data of all instructions 

### DIFF
--- a/src/services/activities/getRecentActivities_service.ts
+++ b/src/services/activities/getRecentActivities_service.ts
@@ -136,8 +136,7 @@ async function queryDatasetsInstructions(
     const { isSuccess, result } =
       await instructionsService.getInstructionsByIds(
         key,
-        datasetsInstructionsMap[key],
-        { projection: { createdAt: 0, updatedAt: 0 } }
+        datasetsInstructionsMap[key]
       );
 
     if (isSuccess && result) {


### PR DESCRIPTION
in `getRecentActivities_service.ts` service file,
Remove the projection option that excludes `createdAt` and `updatedAt` fields from the query that brings 
the instructions from the database to return the full instructions data in the query.