### PR TITLE
Build web sockets connections handling feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import app from "./app";
+import websocketRequestsHandlers from "./websocketRequestsHandlers";
 
 try {
   const serve = await app();
   const server = Bun.serve({
     fetch: serve,
     port: import.meta.env.PORT,
+    websocket: websocketRequestsHandlers,
   });
   console.log("server running on:", server.url.href, "🚀");
 } catch (error: any) {

--- a/src/router/Router.ts
+++ b/src/router/Router.ts
@@ -1,21 +1,22 @@
 import type { Server } from "bun";
-import type { RequestHandler } from "../types/request";
+import type { RequestHandler, WebSocketHandlers } from "../types/request";
 import registerRoute from "./registerRoute";
 import serveRequests from "./serveRequests";
 
-type RouteData = {
-  handlers: RequestHandler[];
+type RouteData<handlersT> = {
+  handlers: handlersT[];
   pathRegExp: RegExp;
   paramsNames: string[];
 };
 
-export type RoutesHandlersRegistery = Record<
+export type RoutesHandlersRegistery<handlersT> = Record<
   string,
-  Record<string, RouteData[]>
+  Record<string, RouteData<handlersT>[]>
 >;
 
 const RouterClass = (function () {
-  const routes: RoutesHandlersRegistery = {};
+  const routes: RoutesHandlersRegistery<RequestHandler> = {};
+  const websocketRoutes: RoutesHandlersRegistery<WebSocketHandlers> = {};
 
   class Router {
     constructor() {}

--- a/src/router/Router.ts
+++ b/src/router/Router.ts
@@ -48,6 +48,10 @@ const RouterClass = (function () {
     PATCH(path: string, ...handlers: RequestHandler[]) {
       this.registerRoute(this.PATCH.name, path, ...handlers);
     }
+
+    WS(path: string, ...handlers: WebSocketHandlers[]) {
+      registerRoute(websocketRoutes, "WS", path, ...handlers);
+    }
   }
 
   return Router;

--- a/src/router/Router.ts
+++ b/src/router/Router.ts
@@ -21,8 +21,8 @@ const RouterClass = (function () {
   class Router {
     constructor() {}
 
-    async serve(request: Request, _server: Server) {
-      return serveRequests(routes, request, _server);
+    async serve(request: Request, server: Server) {
+      return serveRequests(request, server, routes, websocketRoutes);
     }
 
     registerRoute(method: string, path: string, ...handlers: RequestHandler[]) {

--- a/src/router/Router.ts
+++ b/src/router/Router.ts
@@ -26,7 +26,7 @@ const RouterClass = (function () {
     }
 
     registerRoute(method: string, path: string, ...handlers: RequestHandler[]) {
-      registerRoute(routes, method, path, ...handlers);
+      registerRoute<RequestHandler>(routes, method, path, ...handlers);
     }
 
     GET(path: string, ...handlers: RequestHandler[]) {

--- a/src/router/executeRouteHandlers.ts
+++ b/src/router/executeRouteHandlers.ts
@@ -1,32 +1,21 @@
-import extractRequestBody from "../utilities/extractRequestBody";
-import extractSearchParams from "../utilities/extractSearchParams";
-import type { PathParams, Req, RequestHandler } from "../types/request";
+import type { Req, RequestHandler } from "../types/request";
 import globalMiddlewares from "../middlewares/globalMiddlewares";
 
 export default async function executeRouteHandlers(
-  request: Request,
-  routeData: {
-    handlers: RequestHandler[];
-    params: PathParams;
-  }
+  request: Req,
+  handlers: RequestHandler[]
 ): Promise<Response | void> {
-  const req: Req = Object.assign(request, {
-    search: extractSearchParams(new URL(request.url)),
-    json: await extractRequestBody(request),
-    params: routeData.params,
-  });
-
   for (let i = 0; i < globalMiddlewares.length; i++) {
     const handler = globalMiddlewares[i];
-    const response = await handler(req);
+    const response = await handler(request);
     if (response !== undefined) {
       return response;
     }
   }
 
-  for (let i = 0; i < routeData.handlers.length; i++) {
-    const handler = routeData.handlers[i];
-    const response = await handler(req);
+  for (let i = 0; i < handlers.length; i++) {
+    const handler = handlers[i];
+    const response = await handler(request);
     if (response !== undefined) {
       return response;
     }

--- a/src/router/registerRoute.ts
+++ b/src/router/registerRoute.ts
@@ -1,12 +1,11 @@
-import type { RequestHandler } from "../types/request";
 import extractResourceName from "./extractResourceName";
 import type { RoutesHandlersRegistery } from "./Router";
 
-export default function registerRoute(
-  routes: RoutesHandlersRegistery,
+export default function registerRoute<HandlersT>(
+  routes: RoutesHandlersRegistery<HandlersT>,
   method: string,
   path: string,
-  ...handlers: RequestHandler[]
+  ...handlers: HandlersT[]
 ) {
   const paramsNames: string[] = [];
   const regexPath = path.replace(/:([^\/]+)/g, (_, key: string) => {

--- a/src/router/routePathMatcher.ts
+++ b/src/router/routePathMatcher.ts
@@ -2,10 +2,10 @@ import type { PathParams } from "../types/request";
 import extractResourceName from "./extractResourceName";
 import type { RoutesHandlersRegistery } from "./Router";
 
-export default function routePathMatcher(
+export default function routePathMatcher<HandlersT>(
   method: string,
   path: string,
-  routes: RoutesHandlersRegistery
+  routes: RoutesHandlersRegistery<HandlersT>
 ) {
   if (routes[method]) {
     const resourceName = extractResourceName(path);

--- a/src/router/serveRequests.ts
+++ b/src/router/serveRequests.ts
@@ -2,20 +2,47 @@ import type { Server } from "bun";
 import executeRouteHandlers from "./executeRouteHandlers";
 import routePathMatcher from "./routePathMatcher";
 import type { RoutesHandlersRegistery } from "./Router";
+import extractResourceName from "./extractResourceName";
+import extractSearchParams from "../utilities/extractSearchParams";
+import extractRequestBody from "../utilities/extractRequestBody";
+import type { Req, RequestHandler, WebSocketHandlers } from "../types/request";
 
 export default async function serveRequests(
-  routes: RoutesHandlersRegistery,
   request: Request,
-  _server: Server
+  server: Server,
+  routes: RoutesHandlersRegistery<RequestHandler>,
+  websocketRoutes: RoutesHandlersRegistery<WebSocketHandlers>
 ) {
   const url = new URL(request.url);
   const path = url.pathname;
   const method = request.method;
-  const matchedRoute = routePathMatcher(method, path, routes);
+
+  const requestMethodType = extractResourceName(path) === "ws" ? "WS" : method;
+
+  const matchedRoute =
+    requestMethodType === "WS"
+      ? routePathMatcher(requestMethodType, path, websocketRoutes)
+      : routePathMatcher(method, path, routes);
 
   if (matchedRoute) {
-    const res = await executeRouteHandlers(request, matchedRoute);
-    if (res) return res;
+    const req: Req = Object.assign(request, {
+      search: extractSearchParams(new URL(request.url)),
+      json: await extractRequestBody(request),
+      params: matchedRoute.params,
+    });
+
+    if (requestMethodType === "WS") {
+      server.upgrade(request, {
+        data: { req, handlers: matchedRoute.handlers },
+      });
+      return;
+    } else {
+      const res = await executeRouteHandlers(
+        req,
+        matchedRoute.handlers as RequestHandler[]
+      );
+      return res;
+    }
   }
 
   return Response.json(

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,3 +1,5 @@
+import type { ServerWebSocket } from "bun";
+
 export type SearchParams = Record<string, string>;
 export type PathParams = Record<string, any>;
 
@@ -11,3 +13,7 @@ export interface Req extends Request {
 export type RequestHandler = (
   request: Req
 ) => Promise<Response> | Response | void;
+
+export type WebSocketHandlers = (
+  wsClient: ServerWebSocket<{ req: Req; handlers: WebSocketHandlers[] }>
+) => Promise<void | string> | (void | string);

--- a/src/websocketRequestsHandlers.ts
+++ b/src/websocketRequestsHandlers.ts
@@ -1,0 +1,21 @@
+import type { WebSocketServeOptions } from "bun";
+import type { Req, WebSocketHandlers } from "./types/request";
+
+const websocketRequestsHandlers: WebSocketServeOptions<{
+  req: Req;
+  handlers: WebSocketHandlers[];
+}>["websocket"] = {
+  async open(ws) {
+    for (let i = 0; i < ws.data.handlers.length; i++) {
+      const websocketHandler = ws.data.handlers[i];
+      const res = await websocketHandler(ws);
+      if (res) {
+        ws.close(4000, res);
+      }
+    }
+  },
+  message(ws, message) {},
+  close(ws) {},
+};
+
+export default websocketRequestsHandlers;


### PR DESCRIPTION
Create a type represents the web sockets connections handlers (`WebSocketHandlers`) type,
create web sockets routes registry object (`websocketRoutes`), And add the logic that upgrades 
the normal requests to web sockets connections to `serveRequests` function, create the object that 
contains `open` method that receives the successfully upgraded requeststo web socket connection 
and handles executing their routes handlers functions.