### PR TITLE
Update the query that updates a dataset in `incrementInstructionsCount_service`

### DIFF
--- a/src/services/datasets/incrementInstructionsCount_service.ts
+++ b/src/services/datasets/incrementInstructionsCount_service.ts
@@ -13,10 +13,8 @@ export default async function incrementInstructionsCount_service(
   const result = await DatasetModel.updateOne(
     { _id: userId },
     {
-      $set: {
-        [`datasets.$[dataset].instructionsCount`]: {
-          $sum: [`$datasets.$[dataset].instructionsCount`, incrementValue],
-        },
+      $inc: {
+        "datasets.$[dataset].instructionsCount": incrementValue,
       },
     },
     {


### PR DESCRIPTION
Change the update query operator in `incrementInstructionsCount_service` from `$set` stage to `$inc` operator because `$set` stage was used in aggregation pipeline to increment dataset's instructions count, but after the usage of aggregation pipeline has been replaced with the normal update query, the usage of `$set` stage has been not suitble with the normal update query.