### PR TITLE
Create instructions collection model and refactor instructions services methods

### DIFF
--- a/src/controllers/instructions/addInstruction_controller.ts
+++ b/src/controllers/instructions/addInstruction_controller.ts
@@ -9,7 +9,7 @@ export default async function addInstruction_controller(
 ): Promise<Response> {
   try {
     const { result, isSuccess, message } =
-      await instructionsService.addInstruction(request.json);
+      await instructionsService.addInstruction(request.userId, request.json);
 
     if (isSuccess) {
       return SuccessResponse(result, message);

--- a/src/controllers/instructions/deleteInstruction_controller.ts
+++ b/src/controllers/instructions/deleteInstruction_controller.ts
@@ -10,6 +10,7 @@ export default async function deleteInstruction_controller(
   try {
     const { result, isSuccess, message } =
       await instructionsService.deleteInstruction(
+        request.userId,
         request.search.datasetId,
         request.search.instructionId
       );

--- a/src/controllers/instructions/updateInstruction_controller.ts
+++ b/src/controllers/instructions/updateInstruction_controller.ts
@@ -10,6 +10,7 @@ export default async function updateInstruction_controller(
   try {
     const { isSuccess, message, result } =
       await instructionsService.updateInstruction(
+        request.userId,
         request.search.datasetId,
         request.search.instructionId,
         request.json

--- a/src/models/InstructionModel.ts
+++ b/src/models/InstructionModel.ts
@@ -1,6 +1,4 @@
-import mongoose, { Schema, Types, model } from "mongoose";
-import type { Dataset } from "../types/datasets";
-import ServiceOperationResult from "../utilities/ServiceOperationResult";
+import { Schema, Types, model } from "mongoose";
 
 const InstructionSchema = new Schema(
   {
@@ -26,18 +24,6 @@ const InstructionSchema = new Schema(
   }
 );
 
-export default async function InstructionModel(datasetId: Dataset["id"]) {
-  const collectionExists = (await mongoose.connection.listCollections()).some(
-    (collection) => collection.name === datasetId
-  );
+const InstructionModel = model("instructions", InstructionSchema);
 
-  if (collectionExists) {
-    return { Model: model(datasetId, InstructionSchema, datasetId) };
-  }
-
-  return {
-    failure: ServiceOperationResult.failure(
-      "There is no dataset with this id: " + datasetId
-    ),
-  };
-}
+export default InstructionModel;

--- a/src/models/InstructionModel.ts
+++ b/src/models/InstructionModel.ts
@@ -16,6 +16,7 @@ const InstructionSchema = new Schema(
     datasetId: {
       type: Types.ObjectId,
       required: true,
+      index: true,
     },
   },
   {

--- a/src/services/instructions/addInstruction_service.ts
+++ b/src/services/instructions/addInstruction_service.ts
@@ -1,4 +1,3 @@
-import { Types } from "mongoose";
 import createTransactionSession from "../../utilities/createTransactionSession";
 import ServiceOperationResult from "../../utilities/ServiceOperationResult";
 import InstructionModel from "../../models/InstructionModel";
@@ -8,47 +7,50 @@ import datasetsService from "../datasets";
 import activitiesService from "../activities";
 
 export default async function addInstruction_service(
+  userId: string,
   instructionInput: AddInstructionInput
 ): Promise<ServiceOperationResultType> {
   const session = await createTransactionSession();
 
-  const { Model, failure } = await InstructionModel(instructionInput.datasetId);
+  const newInstruction = new InstructionModel(instructionInput);
+  const addInstructionResult = await newInstruction
+    .save({ session })
+    .then(() => true)
+    .catch(() => false);
 
-  if (Model) {
-    const newInstruction = new Model(instructionInput);
-    const addInstructionResult = await newInstruction
-      .save({ session })
-      .then(() => true)
-      .catch(() => false);
+  if (addInstructionResult) {
+    const incrementInstructionsCountResult =
+      await datasetsService.incrementInstructionsCount(
+        userId,
+        instructionInput.datasetId,
+        1,
+        session
+      );
 
-    if (addInstructionResult) {
-      const incrementInstructionsCountResult =
-        await datasetsService.incrementInstructionsCount(
-          instructionInput.datasetId,
-          1,
-          session
-        );
+    if (incrementInstructionsCountResult.isSuccess) {
+      activitiesService.registerInstructionActivity(
+        userId,
+        instructionInput.datasetId,
+        {
+          _id: newInstruction._id,
+          systemMessage: newInstruction.systemMessage,
+          question: newInstruction.question,
+          answer: newInstruction.answer,
+        },
+        newInstruction.createdAt,
+        "New Resource"
+      );
 
-      if (incrementInstructionsCountResult.isSuccess) {
-        await session.commitTransaction();
-        activitiesService.registerInstructionActivity(
-          new Types.ObjectId(instructionInput.datasetId),
-          newInstruction._id,
-          newInstruction.createdAt,
-          "New Resource"
-        );
-        return ServiceOperationResult.success(
-          newInstruction,
-          `The instruction added to the dataset successfully`
-        );
-      }
+      await session.commitTransaction();
+      return ServiceOperationResult.success(
+        newInstruction,
+        `The instruction added to the dataset successfully`
+      );
     }
-
-    await session.abortTransaction();
-    return ServiceOperationResult.failure(
-      `Adding the instruction to the dataset failed`
-    );
-  } else {
-    return failure;
   }
+
+  await session.abortTransaction();
+  return ServiceOperationResult.failure(
+    `Adding the instruction to the dataset failed`
+  );
 }

--- a/src/services/instructions/getInstructionsByIds_service.ts
+++ b/src/services/instructions/getInstructionsByIds_service.ts
@@ -1,28 +1,20 @@
 import ServiceOperationResult from "../../utilities/ServiceOperationResult";
 import InstructionModel from "../../models/InstructionModel";
-import type { Dataset } from "../../types/datasets";
 import type { Instruction } from "../../types/instructions";
 import type { ServiceOperationResultType } from "../../types/response";
 import type { Types } from "mongoose";
 
 export default async function getInstructionsByIds_service(
-  datasetId: Dataset["id"],
   ids: Instruction["id"][] | Types.ObjectId[],
   options?: { projection?: string[] | Record<string, boolean | number> }
 ): Promise<ServiceOperationResultType<Instruction[]>> {
-  const { Model, failure } = await InstructionModel(datasetId);
+  const result = await InstructionModel.find<Instruction>(
+    { _id: { $in: ids } },
+    options?.projection
+  );
 
-  if (Model) {
-    const result = await Model.find<Instruction>(
-      { _id: { $in: ids } },
-      options?.projection
-    );
-
-    return ServiceOperationResult.success(
-      result,
-      !result.length ? "No instructions in this dataset" : undefined
-    );
-  } else {
-    return failure;
-  }
+  return ServiceOperationResult.success(
+    result,
+    !result.length ? "No instructions in this dataset" : undefined
+  );
 }

--- a/src/services/instructions/getInstructions_service.ts
+++ b/src/services/instructions/getInstructions_service.ts
@@ -17,23 +17,17 @@ export default async function getInstructions_service(
 > {
   const { limit, skip } = parsePaginationModel(paginationModel);
 
-  const { Model, failure } = await InstructionModel(datasetId);
+  const result = await InstructionModel.find<Instruction>(
+    { datasetId },
+    {},
+    { limit: limit + 1, skip }
+  );
 
-  if (Model) {
-    const result = await Model.find<Instruction>(
-      {},
-      {},
-      { limit: limit + 1, skip }
-    );
-
-    return ServiceOperationResult.success(
-      {
-        areThereMore: !!result[limit],
-        instructions: result.slice(0, limit),
-      },
-      !result.length && !skip ? "No instructions in this dataset" : undefined
-    );
-  } else {
-    return failure;
-  }
+  return ServiceOperationResult.success(
+    {
+      areThereMore: !!result[limit],
+      instructions: result.slice(0, limit),
+    },
+    !result.length && !skip ? "No instructions in this dataset" : undefined
+  );
 }


### PR DESCRIPTION
Instead of letting `InstructionModel` function creates at runtime the model of interacting with dataset's inctructions
collection (because each dataset was having its own collection to store its instruction), Create `InstructionModel` model
and make it interacts with "instructions" normally because all datasets instructions are now stored in "instructions" 
collection.

And then refactor the services functions that are supposed to deal with the new instructions collection and which are the 
methods  of `InstructionsService` class: `addInstruction`, `updateInstruction`, `updateInstruction`, `getInstructionsByIds` 
and `getInstructionById` methods