### PR TITLE
Create dataset instructions stream service

### DIFF
--- a/src/controllers/export/exportDataset_controller.ts
+++ b/src/controllers/export/exportDataset_controller.ts
@@ -14,6 +14,7 @@ export default async function exportDataset_controller(
       isSuccess,
       result: Stream,
     } = await exportService.exportDataset(
+      request.userId,
       request.params.datasetId,
       formaters[request.search.format as DatasetsFormatsTypes]
     );

--- a/src/controllers/export/index.ts
+++ b/src/controllers/export/index.ts
@@ -1,9 +1,9 @@
-import export_controller from "./exportDataset_controller";
+import exportDataset_controller from "./exportDataset_controller";
 
 class ExportDatasetController {
   constructor() {}
 
-  exportDataset = export_controller;
+  exportDataset = exportDataset_controller;
 }
 
 const exportDatasetController = new ExportDatasetController();

--- a/src/services/export/datasetInstructionsStream_service.ts
+++ b/src/services/export/datasetInstructionsStream_service.ts
@@ -1,0 +1,59 @@
+import type { Dataset } from "../../types/datasets";
+import type { DatasetFormat } from "../../types/datasets";
+import getDatasetInstructionsReader from "./getDatasetInstructionsReader";
+
+export type DatasetInstructionsStreamOptions = {
+  userId: string;
+  datasetId: Dataset["id"];
+  datasetFormat: DatasetFormat;
+  onChunk: (chunk: string, progress: number, done?: boolean) => void;
+};
+
+export default async function datasetInstructionsStream_service({
+  userId,
+  datasetId,
+  datasetFormat,
+  onChunk,
+}: DatasetInstructionsStreamOptions) {
+  const { cursor, dataset, failure } = await getDatasetInstructionsReader(
+    userId,
+    datasetId
+  );
+  if (cursor) {
+    const instructionsPerchunks = 10;
+    const totalChunks = Math.ceil(
+      dataset.instructionsCount / instructionsPerchunks
+    );
+    let progress = 0;
+    let done = false;
+
+    await cursor.eachAsync(
+      async (instruction, i) => {
+        progress = +(((i + 1) / totalChunks) * 100).toFixed(2);
+        done = i + 1 === totalChunks;
+        onChunk(
+          instruction.reduce((chunk, instruction) => {
+            chunk += datasetFormat.formater({
+              systemMessage: instruction.systemMessage || undefined,
+              question: instruction.question,
+              answer: instruction.answer,
+            });
+
+            if (done && datasetFormat.decorators?.last) {
+              return chunk + datasetFormat.decorators?.last || "";
+            }
+
+            return chunk;
+          }, datasetFormat.decorators?.first || ""),
+          progress,
+          done
+        );
+      },
+      { batchSize: instructionsPerchunks }
+    );
+
+    return true;
+  } else {
+    return failure;
+  }
+}

--- a/src/services/export/datasetInstructionsStream_service.ts
+++ b/src/services/export/datasetInstructionsStream_service.ts
@@ -51,9 +51,7 @@ export default async function datasetInstructionsStream_service({
       },
       { batchSize: instructionsPerchunks }
     );
-
-    return true;
   } else {
-    return failure;
+    throw failure.message;
   }
 }

--- a/src/services/export/exportDataset_service.ts
+++ b/src/services/export/exportDataset_service.ts
@@ -2,42 +2,26 @@ import type { Dataset } from "../../types/datasets";
 import type { DatasetFormat } from "../../types/datasets";
 import type { ServiceOperationResultType } from "../../types/response";
 import ServiceOperationResult from "../../utilities/ServiceOperationResult";
-import getDatasetInstructionsReader from "./getDatasetInstructionsReader";
+import datasetInstructionsStream_service from "./datasetInstructionsStream_service";
 
 export default async function exportDataset_service(
+  userId: string,
   datasetId: Dataset["id"],
   datasetFormat: DatasetFormat
 ): Promise<ServiceOperationResultType<ReadableStream>> {
-  const { cursor, failure } = await getDatasetInstructionsReader(datasetId);
+  const Stream = new ReadableStream({
+    async pull(controller) {
+      await datasetInstructionsStream_service({
+        userId,
+        datasetId,
+        datasetFormat,
+        onChunk(chunk, _progress, done) {
+          controller.enqueue(chunk);
+          done && controller.close();
+        },
+      });
+    },
+  });
 
-  if (cursor) {
-    const Stream = new ReadableStream({
-      async pull(controller) {
-        datasetFormat.decorators?.first &&
-          controller.enqueue(datasetFormat.decorators.first);
-
-        for (
-          let instruction = await cursor.next();
-          instruction != null;
-          instruction = await cursor.next()
-        ) {
-          controller.enqueue(
-            datasetFormat.formater({
-              systemMessage: instruction.systemMessage || undefined,
-              question: instruction.question,
-              answer: instruction.answer,
-            })
-          );
-        }
-        datasetFormat.decorators?.last &&
-          controller.enqueue(datasetFormat.decorators.last);
-
-        controller.close();
-      },
-    });
-
-    return ServiceOperationResult.success(Stream);
-  } else {
-    return failure;
-  }
+  return ServiceOperationResult.success(Stream);
 }

--- a/src/services/export/exportDataset_service.ts
+++ b/src/services/export/exportDataset_service.ts
@@ -11,15 +11,19 @@ export default async function exportDataset_service(
 ): Promise<ServiceOperationResultType<ReadableStream>> {
   const Stream = new ReadableStream({
     async pull(controller) {
-      await datasetInstructionsStream_service({
-        userId,
-        datasetId,
-        datasetFormat,
-        onChunk(chunk, _progress, done) {
-          controller.enqueue(chunk);
-          done && controller.close();
-        },
-      });
+      try {
+        await datasetInstructionsStream_service({
+          userId,
+          datasetId,
+          datasetFormat,
+          onChunk(chunk, _progress, done) {
+            controller.enqueue(chunk);
+            done && controller.close();
+          },
+        });
+      } catch {
+        controller.close();
+      }
     },
   });
 


### PR DESCRIPTION
Create `datasetInstructionsStream_service` function to provide a simple and direct way to read the instructions of a specific
dataset in chunks to export the instructions of the dataset as file (in `csv` or `jsonl` format).

The function uses `getDatasetInstructionsReader` function to get the cursor that allows it to read the instructions from the
database group by group and it takes each group of instructions and formats them in the requested format and calls the callback
function `onChunk` (that is passed as parapeter) with the formated group of instructions as chunk of file.

And then make `exportDataset_service` function reuses the function `datasetInstructionsStream_service` (that streams the instructions 
of the given dataset as chunks) to send the chunks of dataset instructions file to the consumer through the readable stream.

Also make `exportDataset_controller` function passes user's id to `exportDataset_service` function.
