### PR TITLE
Build exporting datasets via web socket connection feature

### DIFF
--- a/src/controllers/export/exportDatasetWS_controller.ts
+++ b/src/controllers/export/exportDatasetWS_controller.ts
@@ -1,0 +1,24 @@
+import type { Req } from "../../types/request";
+import exportService from "../../services/export";
+import formaters from "../../services/export/datasetsFormatsRegistry";
+import type { DatasetsFormatsTypes } from "../../types/datasets";
+import type { ServerWebSocket } from "bun";
+
+export default async function exportDatasetWS_controller(
+  wsClient: ServerWebSocket<{ req: Req }>
+): Promise<void> {
+  try {
+    const request = wsClient.data.req;
+    const chosenFormat =
+      formaters[request.search.format as DatasetsFormatsTypes];
+
+    await exportService.exportDatasetWS({
+      userId: request.userId,
+      datasetId: request.params.datasetId,
+      datasetFormat: chosenFormat,
+      wsClient,
+    });
+  } catch (error: any) {
+    wsClient.close(4000, error || "Internal Server Error");
+  }
+}

--- a/src/controllers/export/index.ts
+++ b/src/controllers/export/index.ts
@@ -1,9 +1,11 @@
 import exportDataset_controller from "./exportDataset_controller";
+import exportDatasetWS_controller from "./exportDatasetWS_controller";
 
 class ExportDatasetController {
   constructor() {}
 
   exportDataset = exportDataset_controller;
+  exportDatasetWS = exportDatasetWS_controller;
 }
 
 const exportDatasetController = new ExportDatasetController();

--- a/src/middlewares/exportDatasetInputValidator.ts
+++ b/src/middlewares/exportDatasetInputValidator.ts
@@ -7,6 +7,7 @@ import RequiredObjectIdRule from "../validation/RequiredObjectIdRule";
 import { DatasetsFormats } from "../services/export/datasetsFormatsRegistry";
 import stringValidator from "../validation/stringValidator";
 import type { DatasetsFormatsTypes } from "../types/datasets";
+import type { ServerWebSocket } from "bun";
 
 const exportDatasetInputSchema = validationSchema<{
   datasetId: Dataset["id"];
@@ -25,5 +26,19 @@ export default function exportDatasetInputValidator(request: Req) {
   } catch (e: any) {
     const validationErrors = e.errors as ValidationError["errors"];
     return ErrorResponse({ validationErrors }, 403);
+  }
+}
+
+export async function exportDatasetInputValidatorWS(
+  wsClient: ServerWebSocket<{ req: Req }>
+) {
+  try {
+    exportDatasetInputSchema.validate({
+      datasetId: wsClient.data.req.params.datasetId,
+      format: wsClient.data.req.search.format,
+    });
+  } catch (e: any) {
+    const validationErrors = e.errors as ValidationError["errors"];
+    return JSON.stringify(validationErrors);
   }
 }

--- a/src/services/export/exportDatasetWS_service.ts
+++ b/src/services/export/exportDatasetWS_service.ts
@@ -1,0 +1,29 @@
+import type { ServerWebSocket } from "bun";
+import type { Dataset } from "../../types/datasets";
+import type { DatasetFormat } from "../../types/datasets";
+import datasetInstructionsStream_service from "./datasetInstructionsStream_service";
+import type { Req } from "../../types/request";
+
+type ExportDatasetWSProps = {
+  userId: string;
+  datasetId: Dataset["id"];
+  datasetFormat: DatasetFormat;
+  wsClient: ServerWebSocket<{ req: Req }>;
+};
+
+export default async function exportDatasetWS_service({
+  userId,
+  datasetId,
+  datasetFormat,
+  wsClient,
+}: ExportDatasetWSProps) {
+  await datasetInstructionsStream_service({
+    userId,
+    datasetId,
+    datasetFormat,
+    onChunk(chunk, progress, done) {
+      wsClient.send(JSON.stringify({ chunk, progress, done }));
+      done && wsClient.close();
+    },
+  });
+}

--- a/src/services/export/index.ts
+++ b/src/services/export/index.ts
@@ -1,9 +1,11 @@
 import exportDataset_service from "./exportDataset_service";
+import exportDatasetWS_service from "./exportDatasetWS_service";
 
 class ExportDatasetService {
   constructor() {}
 
   exportDataset = exportDataset_service;
+  exportDatasetWS = exportDatasetWS_service;
 }
 
 const exportDatasetService = new ExportDatasetService();


### PR DESCRIPTION
First create `exportDatasetInputValidatorWS` middleware function inside `src/middlewares/exportDatasetInputValidator.ts` 
file to provide validation for the inputs that come with the web socket connection URL to export a dataset,

Create `exportDatasetWS_service` function which is the service function that handles exporting dataset instructions
file chunk by chunk through web socket connection.

And create `exportDatasetWS_controller` function which is acts as presentation layer of "export datasets through web sockets"
service, Receives the web sockets connections and call `exportDatasetWS` to start exporting the dataset.