### PR TITLE
Collect all services operations results messages in one file

### DIFF
--- a/src/constants/operationsResultsMessages.ts
+++ b/src/constants/operationsResultsMessages.ts
@@ -23,7 +23,7 @@ const operationsResultsMessages = {
     "Failed to delete the instruction from the dataset",
   noInstructionToDelete:
     "The targeted instruction not found to delete it from the dataset",
-  successfullInstructionUpdate: "The instruction updated successfully",
+  successfulInstructionUpdate: "The instruction updated successfully",
   failedInstructionUpdate: "Failed to update the instruction",
 
   noUser: (userId: string) => `There is no user with "${userId}" id`,

--- a/src/constants/operationsResultsMessages.ts
+++ b/src/constants/operationsResultsMessages.ts
@@ -31,6 +31,8 @@ const operationsResultsMessages = {
     "The targeted instruction not found to delete it from the dataset",
   successfulInstructionUpdate: "The instruction updated successfully",
   failedInstructionUpdate: "Failed to update the instruction",
+  noInstructionsFoundByIds: "No instructions found by the provided ids",
+  noInstructionsIdsProvided: "No instructions ids provided",
 
   noUser: (userId: string) => `There is no user with "${userId}" id`,
 };

--- a/src/constants/operationsResultsMessages.ts
+++ b/src/constants/operationsResultsMessages.ts
@@ -8,9 +8,11 @@ const operationsResultsMessages = {
   noDataset: (datasetId: string) =>
     `There is no dataset with "${datasetId}" id`,
   successfulDatasetDeletion: "The dataset was deleted successfully",
-  failedDatasetDeletion: "",
   noInstructionsForDataset: (datasetId: string) =>
     `No instructions found for a dataset with this id: ${datasetId}`,
+  successfulInstructionsCountIncrement:
+    "Instructions count incremented successfully",
+  failedInstructionsCountIncrement: "Faild to increment instructions count",
 
   successfulInstructionAddition:
     "The instruction was added to the dataset successfully",

--- a/src/constants/operationsResultsMessages.ts
+++ b/src/constants/operationsResultsMessages.ts
@@ -1,0 +1,30 @@
+const operationsResultsMessages = {
+  successfulDatasetCreation: (datasetName: string) =>
+    `"${datasetName}" dataset created successfuly`,
+  successfulDatasetUpdate: "The dataset was updated successfully",
+  failedDatasetCreation: (datasetName: string) =>
+    `"${datasetName}" dataset creation failed`,
+  noDatasets: "There are no datasets yet",
+  noDataset: (datasetId: string) =>
+    `There is no dataset with "${datasetId}" id`,
+  successfulDatasetDeletion: "The dataset was deleted successfully",
+  failedDatasetDeletion: "",
+  noInstructionsForDataset: (datasetId: string) =>
+    `No instructions found for a dataset with this id: ${datasetId}`,
+
+  successfulInstructionAddition:
+    "The instruction was added to the dataset successfully",
+  failedInstructionAddition: "Adding the instruction to the dataset failed",
+  successfulInstructionDeletion:
+    "The instruction was deleted from the dataset successfully",
+  failedInstructionDeletion:
+    "Failed to delete the instruction from the dataset",
+  noInstructionToDelete:
+    "The targeted instruction not found to delete it from the dataset",
+  successfullInstructionUpdate: "The instruction updated successfully",
+  failedInstructionUpdate: "Failed to update the instruction",
+
+  noUser: (userId: string) => `There is no user with "${userId}" id`,
+};
+
+export default operationsResultsMessages;

--- a/src/constants/operationsResultsMessages.ts
+++ b/src/constants/operationsResultsMessages.ts
@@ -13,6 +13,12 @@ const operationsResultsMessages = {
   successfulInstructionsCountIncrement:
     "Instructions count incremented successfully",
   failedInstructionsCountIncrement: "Faild to increment instructions count",
+  successfulAllInstructionsDeletion:
+    "The instructions of the dataset was deleted successfully",
+  failedDeletingAllInstructions:
+    "Deleting the instructions of this dataset failed",
+  noInstructionsToDelete:
+    "There are no instructions to delete from this dataset",
 
   successfulInstructionAddition:
     "The instruction was added to the dataset successfully",

--- a/src/services/datasets/createDataset_service.ts
+++ b/src/services/datasets/createDataset_service.ts
@@ -4,6 +4,7 @@ import type { DatasetInput } from "../../types/datasets";
 import type { ServiceOperationResultType } from "../../types/response";
 import ServiceOperationResult from "../../utilities/ServiceOperationResult";
 import activitiesService from "../activities";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function createDataset_service(
   userId: string,
@@ -36,12 +37,12 @@ export default async function createDataset_service(
 
     return ServiceOperationResult.success(
       newDataset,
-      `"${newDataset.name}" dataset created successfuly`
+      operationsResultsMessages.successfulDatasetCreation(newDataset.name)
     );
   }
 
   await session.abortTransaction();
   return ServiceOperationResult.failure(
-    `"${newDataset.name}" dataset creation failed`
+    operationsResultsMessages.failedDatasetCreation(newDataset.name)
   );
 }

--- a/src/services/datasets/deleteDataset_service.ts
+++ b/src/services/datasets/deleteDataset_service.ts
@@ -1,3 +1,4 @@
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 import DatasetsModel from "../../models/DatasetsModel";
 import type { Dataset } from "../../types/datasets";
 import type { ServiceOperationResultType } from "../../types/response";
@@ -43,7 +44,7 @@ export default async function deleteDataset_service(
         await session.commitTransaction();
         return ServiceOperationResult.success(
           true,
-          `The dataset was deleted successfully`
+          operationsResultsMessages.successfulDatasetDeletion
         );
       } else {
         session.abortTransaction();
@@ -52,13 +53,13 @@ export default async function deleteDataset_service(
     } else {
       session.abortTransaction();
       return ServiceOperationResult.failure(
-        `There is no dataset with "${datasetId}" id`
+        operationsResultsMessages.noDataset(datasetId)
       );
     }
   } else {
     session.abortTransaction();
     return ServiceOperationResult.failure(
-      `There is no user with "${userId}" id`
+      operationsResultsMessages.noUser(userId)
     );
   }
 }

--- a/src/services/datasets/getDatasetById_service.ts
+++ b/src/services/datasets/getDatasetById_service.ts
@@ -3,6 +3,7 @@ import DatasetModel from "../../models/DatasetsModel";
 import type { Dataset } from "../../types/datasets";
 import type { ServiceOperationResultType } from "../../types/response";
 import type { Types } from "mongoose";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function getDatasetById_service(
   userId: string,
@@ -20,7 +21,7 @@ export default async function getDatasetById_service(
     return ServiceOperationResult.success(result.datasets[0]);
   } else {
     return ServiceOperationResult.failure(
-      `There is no dataset with "${datasetId}" id`
+      operationsResultsMessages.noDataset(datasetId)
     );
   }
 }

--- a/src/services/datasets/getDatasets_service.ts
+++ b/src/services/datasets/getDatasets_service.ts
@@ -1,14 +1,21 @@
 import ServiceOperationResult from "../../utilities/ServiceOperationResult";
 import DatasetsModel from "../../models/DatasetsModel";
 import type { ServiceOperationResultType } from "../../types/response";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function getDatasets_service(
   userId: string
 ): Promise<ServiceOperationResultType> {
   const result = await DatasetsModel.findOne({ _id: userId });
 
-  return ServiceOperationResult.success(
-    result?.datasets || [],
-    result?.datasets.length ? undefined : "There are no datasets yet"
-  );
+  if (result) {
+    return ServiceOperationResult.success(
+      result.datasets,
+      result.datasets.length ? undefined : operationsResultsMessages.noDatasets
+    );
+  } else {
+    return ServiceOperationResult.failure(
+      operationsResultsMessages.noUser(userId)
+    );
+  }
 }

--- a/src/services/datasets/getDatasets_service.ts
+++ b/src/services/datasets/getDatasets_service.ts
@@ -8,14 +8,8 @@ export default async function getDatasets_service(
 ): Promise<ServiceOperationResultType> {
   const result = await DatasetsModel.findOne({ _id: userId });
 
-  if (result) {
-    return ServiceOperationResult.success(
-      result.datasets,
-      result.datasets.length ? undefined : operationsResultsMessages.noDatasets
-    );
-  } else {
-    return ServiceOperationResult.failure(
-      operationsResultsMessages.noUser(userId)
-    );
-  }
+  return ServiceOperationResult.success(
+    result?.datasets || [],
+    result?.datasets.length ? undefined : operationsResultsMessages.noDatasets
+  );
 }

--- a/src/services/datasets/incrementInstructionsCount_service.ts
+++ b/src/services/datasets/incrementInstructionsCount_service.ts
@@ -3,6 +3,7 @@ import ServiceOperationResult from "../../utilities/ServiceOperationResult";
 import DatasetModel from "../../models/DatasetsModel";
 import type { Dataset } from "../../types/datasets";
 import type { ServiceOperationResultType } from "../../types/response";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function incrementInstructionsCount_service(
   userId: string,
@@ -26,15 +27,15 @@ export default async function incrementInstructionsCount_service(
   if (result.modifiedCount) {
     return ServiceOperationResult.success(
       true,
-      "Instructions count incremented successfully"
+      operationsResultsMessages.successfulInstructionsCountIncrement
     );
   } else if (!result.matchedCount) {
     return ServiceOperationResult.failure(
-      `There is no dataset with "${datasetId}" id`
+      operationsResultsMessages.noDataset(datasetId)
     );
   } else {
     return ServiceOperationResult.failure(
-      "Faild to increment instructions count"
+      operationsResultsMessages.failedInstructionsCountIncrement
     );
   }
 }

--- a/src/services/datasets/updateDataset_service.ts
+++ b/src/services/datasets/updateDataset_service.ts
@@ -1,3 +1,4 @@
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 import DatasetModel from "../../models/DatasetsModel";
 import type { Dataset, UpdateDatasetInput } from "../../types/datasets";
 import type { ServiceOperationResultType } from "../../types/response";
@@ -42,16 +43,16 @@ export default async function updateDataset_service(
       );
       return ServiceOperationResult.success(
         result.datasets.find((dataset) => dataset.id === datasetId),
-        `The dataset updated successfully`
+        operationsResultsMessages.successfulDatasetUpdate
       );
     } else {
       return ServiceOperationResult.failure(
-        `There is no dataset with "${datasetId}" id`
+        operationsResultsMessages.noDataset(datasetId)
       );
     }
   } else {
     return ServiceOperationResult.failure(
-      `There is no user with "${userId}" id`
+      operationsResultsMessages.noUser(userId)
     );
   }
 }

--- a/src/services/instructions/addInstruction_service.ts
+++ b/src/services/instructions/addInstruction_service.ts
@@ -5,6 +5,7 @@ import type { AddInstructionInput } from "../../types/instructions";
 import type { ServiceOperationResultType } from "../../types/response";
 import datasetsService from "../datasets";
 import activitiesService from "../activities";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function addInstruction_service(
   userId: string,
@@ -44,13 +45,13 @@ export default async function addInstruction_service(
       await session.commitTransaction();
       return ServiceOperationResult.success(
         newInstruction,
-        `The instruction added to the dataset successfully`
+        operationsResultsMessages.successfulInstructionAddition
       );
     }
   }
 
   await session.abortTransaction();
   return ServiceOperationResult.failure(
-    `Adding the instruction to the dataset failed`
+    operationsResultsMessages.failedInstructionAddition
   );
 }

--- a/src/services/instructions/deleteAllDatasetInstructions_service.ts
+++ b/src/services/instructions/deleteAllDatasetInstructions_service.ts
@@ -3,6 +3,7 @@ import InstructionModel from "../../models/InstructionModel";
 import type { Dataset } from "../../types/datasets";
 import type { ServiceOperationResultType } from "../../types/response";
 import type { ClientSession } from "mongoose";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function deleteAllDatasetInstructions_service(
   datasetId: Dataset["id"],
@@ -16,18 +17,18 @@ export default async function deleteAllDatasetInstructions_service(
   if (deletedCount) {
     return ServiceOperationResult.success(
       true,
-      `The instructions of the dataset was deleted successfully`
+      operationsResultsMessages.successfulAllInstructionsDeletion
     );
   }
 
   if (acknowledged) {
     return ServiceOperationResult.success(
       true,
-      `There is no instructions to delete from this dataset`
+      operationsResultsMessages.noInstructionsToDelete
     );
   } else {
     return ServiceOperationResult.failure(
-      `Deleting the instructions of this dataset failed`
+      operationsResultsMessages.failedDeletingAllInstructions
     );
   }
 }

--- a/src/services/instructions/deleteInstruction_service.ts
+++ b/src/services/instructions/deleteInstruction_service.ts
@@ -6,6 +6,7 @@ import type { Instruction } from "../../types/instructions";
 import type { ServiceOperationResultType } from "../../types/response";
 import activitiesService from "../activities";
 import datasetsService from "../datasets";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function deleteInstruction_service(
   userId: string,
@@ -43,18 +44,18 @@ export default async function deleteInstruction_service(
       await session.commitTransaction();
       return ServiceOperationResult.success(
         true,
-        `The instruction deleted from the dataset successfully`
+        operationsResultsMessages.successfulInstructionDeletion
       );
     } else {
       await session.abortTransaction();
       return ServiceOperationResult.failure(
-        `Deleting the instruction from the dataset failed`
+        operationsResultsMessages.failedInstructionDeletion
       );
     }
   } else {
     await session.abortTransaction();
     return ServiceOperationResult.failure(
-      `The targeted instruction not found to delete it from the dataset`
+      operationsResultsMessages.noInstructionToDelete
     );
   }
 }

--- a/src/services/instructions/getInstructionsByIds_service.ts
+++ b/src/services/instructions/getInstructionsByIds_service.ts
@@ -3,11 +3,18 @@ import InstructionModel from "../../models/InstructionModel";
 import type { Instruction } from "../../types/instructions";
 import type { ServiceOperationResultType } from "../../types/response";
 import type { Types } from "mongoose";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function getInstructionsByIds_service(
   ids: Instruction["id"][] | Types.ObjectId[],
   options?: { projection?: string[] | Record<string, boolean | number> }
 ): Promise<ServiceOperationResultType<Instruction[]>> {
+  if (!ids.length) {
+    return ServiceOperationResult.failure(
+      operationsResultsMessages.noInstructionsIdsProvided
+    );
+  }
+
   const result = await InstructionModel.find<Instruction>(
     { _id: { $in: ids } },
     options?.projection
@@ -15,6 +22,8 @@ export default async function getInstructionsByIds_service(
 
   return ServiceOperationResult.success(
     result,
-    !result.length ? "No instructions in this dataset" : undefined
+    !result.length
+      ? operationsResultsMessages.noInstructionsFoundByIds
+      : undefined
   );
 }

--- a/src/services/instructions/getInstructions_service.ts
+++ b/src/services/instructions/getInstructions_service.ts
@@ -8,6 +8,7 @@ import type {
   PaginationResponse,
   ServiceOperationResultType,
 } from "../../types/response";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function getInstructions_service(
   datasetId: Dataset["id"],
@@ -28,6 +29,8 @@ export default async function getInstructions_service(
       areThereMore: !!result[limit],
       instructions: result.slice(0, limit),
     },
-    !result.length && !skip ? "No instructions in this dataset" : undefined
+    !result.length && !skip
+      ? operationsResultsMessages.noInstructionsForDataset(datasetId)
+      : undefined
   );
 }

--- a/src/services/instructions/updateInstruction_service.ts
+++ b/src/services/instructions/updateInstruction_service.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../types/instructions";
 import activitiesService from "../activities";
 import type { ServiceOperationResultType } from "../../types/response";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function updateInstruction_service(
   userId: string,
@@ -36,9 +37,11 @@ export default async function updateInstruction_service(
 
     return ServiceOperationResult.success(
       updatedInstruction,
-      "The instruction updated successfully"
+      operationsResultsMessages.successfulInstructionUpdate
     );
   }
 
-  return ServiceOperationResult.failure("Failed to update the instruction");
+  return ServiceOperationResult.failure(
+    operationsResultsMessages.failedInstructionUpdate
+  );
 }


### PR DESCRIPTION
Create a centralized file (`src/constants/operationsResultsMessages.ts`) to collect all services operations 
results messages in one file and reuse those messages anywhere.