### PR TITLE
Fix a mistake led to return success responses always in `getDatasets_controller` function

### DIFF
--- a/src/controllers/datasets/getDatasets_controller.ts
+++ b/src/controllers/datasets/getDatasets_controller.ts
@@ -2,15 +2,20 @@ import InternalServerErrorResponse from "../../utilities/InternalServerErrorResp
 import SuccessResponse from "../../utilities/SuccessResponse";
 import datasetsService from "../../services/datasets";
 import type { Req } from "../../types/request";
+import ErrorResponse from "../../utilities/ErrorResponse";
 
 export default async function getDatasets_controller(
   request: Req
 ): Promise<Response> {
   try {
-    const { result, message } = await datasetsService.getDatasets(
+    const { isSuccess, result, message } = await datasetsService.getDatasets(
       request.userId
     );
-    return SuccessResponse(result, message);
+    if (isSuccess) {
+      return SuccessResponse(result, message);
+    } else {
+      return ErrorResponse(message as string, 404);
+    }
   } catch {
     return InternalServerErrorResponse();
   }


### PR DESCRIPTION
Add success check to `getDatasets_controller` function to specify if success response will be returned or error response.