### PR TITLE
Add logging service to recent activities registration service

### DIFF
--- a/src/constants/operationsResultsMessages.ts
+++ b/src/constants/operationsResultsMessages.ts
@@ -35,6 +35,8 @@ const operationsResultsMessages = {
   noInstructionsIdsProvided: "No instructions ids provided",
 
   noUser: (userId: string) => `There is no user with "${userId}" id`,
+
+  failedActivityRegistration: "Activity registration failed",
 };
 
 export default operationsResultsMessages;

--- a/src/services/activities/registerActivity_service.ts
+++ b/src/services/activities/registerActivity_service.ts
@@ -2,6 +2,7 @@ import ServiceOperationResult from "../../utilities/ServiceOperationResult";
 import RecentActivitiesModel from "../../models/RecentActivitiesModel";
 import type { Activity, ActivityResource } from "../../types/activities";
 import type { ServiceOperationResultType } from "../../types/response";
+import operationsResultsMessages from "../../constants/operationsResultsMessages";
 
 export default async function registerActivity_service(
   resourceName: ActivityResource,
@@ -28,5 +29,8 @@ export default async function registerActivity_service(
     return ServiceOperationResult.success(true);
   }
 
-  return ServiceOperationResult.failure("Activity registration failed", false);
+  return ServiceOperationResult.failure(
+    operationsResultsMessages.failedActivityRegistration,
+    false
+  );
 }

--- a/src/services/activities/registerDatasetActivity_service.ts
+++ b/src/services/activities/registerDatasetActivity_service.ts
@@ -1,4 +1,5 @@
 import type { ActivitiesTypes, DatasetActivity } from "../../types/activities";
+import loggerService from "../logger";
 import registerActivity_service from "./registerActivity_service";
 
 export default async function registerDatasetActivity_service(
@@ -18,6 +19,10 @@ export default async function registerDatasetActivity_service(
       userId
     );
   } catch {
-    // logging system
+    loggerService.error(`Failed to register '${activity}' dataset activity`, {
+      service: "registerDatasetActivity_service",
+      userId,
+      datasetId: dataset._id.toString(),
+    });
   }
 }

--- a/src/services/activities/registerInstructionActivity_service.ts
+++ b/src/services/activities/registerInstructionActivity_service.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../types/activities";
 import registerActivity_service from "./registerActivity_service";
 import datasetsService from "../datasets";
+import loggerService from "../logger";
 
 export default async function registerInstructionActivity_service(
   userId: string,
@@ -31,6 +32,14 @@ export default async function registerInstructionActivity_service(
       );
     }
   } catch {
-    // logging system
+    loggerService.error(
+      `Failed to register '${activity}' instruction activity`,
+      {
+        service: "registerInstructionActivity_service",
+        userId,
+        datasetId: datasetId,
+        instructionId: instruction._id.toString(),
+      }
+    );
   }
 }


### PR DESCRIPTION
Use `loggerService` service object to log the errors that occurr when registering datasets and instructions activities
in the services function `registerDatasetActivity_service.ts` and `registerInstructionActivity_service`