### PR TITLE
Establish database connection before integration tests

### DIFF
--- a/tests/integration/datasets/incrementInstructionsCount.test.ts
+++ b/tests/integration/datasets/incrementInstructionsCount.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, afterAll } from "bun:test";
+import { describe, expect, it, afterAll, beforeAll } from "bun:test";
 import { getRandomFakeDataset } from "../../fake-data/fakeDatasets";
 import DatasetsModel from "../../../src/models/DatasetsModel";
 import incrementInstructionsCount_service from "../../../src/services/datasets/incrementInstructionsCount_service";
 import operationsResultsMessages from "../../../src/constants/operationsResultsMessages";
+import databaseConnection from "../../../src/configurations/databaseConnection";
+
+beforeAll(async () => {
+  await databaseConnection();
+});
 
 describe("Test `incrementInstructionsCount_service` service function", () => {
   it("Should fail to increment the instructions count of the dataset because the dataset is not exist", async () => {

--- a/tests/integration/instructions/deleteAllDatasetInstructions.test.ts
+++ b/tests/integration/instructions/deleteAllDatasetInstructions.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it, afterAll } from "bun:test";
+import { describe, expect, it, afterAll, beforeAll } from "bun:test";
 import { getRandomFakeDataset } from "../../fake-data/fakeDatasets";
 import operationsResultsMessages from "../../../src/constants/operationsResultsMessages";
 import InstructionModel from "../../../src/models/InstructionModel";
 import { getFakeInstructions } from "../../fake-data/fakeInstructions";
 import deleteAllDatasetInstructions_service from "../../../src/services/instructions/deleteAllDatasetInstructions_service";
+import databaseConnection from "../../../src/configurations/databaseConnection";
+
+beforeAll(async () => {
+  await databaseConnection();
+});
 
 describe("Test `deleteAllDatasetInstructions` service function", () => {
   it("Should not delete anything because there are no instructions in the dataset", async () => {

--- a/tests/integration/instructions/getInstructionsByIds.test.ts
+++ b/tests/integration/instructions/getInstructionsByIds.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it, afterAll } from "bun:test";
+import { describe, expect, it, afterAll, beforeAll } from "bun:test";
 import { getRandomFakeDataset } from "../../fake-data/fakeDatasets";
 import operationsResultsMessages from "../../../src/constants/operationsResultsMessages";
 import InstructionModel from "../../../src/models/InstructionModel";
 import { getFakeInstructions } from "../../fake-data/fakeInstructions";
 import getInstructionsByIds_service from "../../../src/services/instructions/getInstructionsByIds_service";
 import { Types } from "mongoose";
+import databaseConnection from "../../../src/configurations/databaseConnection";
+
+beforeAll(async () => {
+  await databaseConnection();
+});
 
 describe("Test `getInstructionsByIds` service function", () => {
   it('Should return an error says that "the instructions ids are not provided"', async () => {


### PR DESCRIPTION
Use `beforeAll` helper function to establish the database connection before all integration tests.