### PR TITLE
Write unit tests for two functions

### DIFF
--- a/tests/unit/extractSearchParams.test.ts
+++ b/tests/unit/extractSearchParams.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import extractSearchParams from "../../src/utilities/extractSearchParams";
+
+describe("Test `extractSearchParams` utility function", () => {
+  it("Should return an object contains the search params", () => {
+    expect(
+      extractSearchParams(
+        new URL("http://localhost/?searchParam1=value1&searchParam2=value2")
+      )
+    ).toEqual({
+      searchParam1: "value1",
+      searchParam2: "value2",
+    });
+  });
+
+  it("Should return an empty object because there are no search params", () => {
+    expect(extractSearchParams(new URL("http://localhost"))).toEqual({});
+  });
+});

--- a/tests/unit/parsePaginationModel.test.ts
+++ b/tests/unit/parsePaginationModel.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import parsePaginationModel from "../../src/utilities/parsePaginationModel";
+
+describe("Test `parsePaginationModel` utility function", () => {
+  it("Should return an object contains right`skip` and `limit` values", () => {
+    expect(parsePaginationModel({ page: 1, pageSize: 20 })).toEqual({
+      skip: 0,
+      limit: 20,
+    });
+  });
+
+  it("Should return an object contains right `skip` and `limit` values", () => {
+    expect(parsePaginationModel({ page: 5, pageSize: 5 })).toEqual({
+      skip: 20,
+      limit: 5,
+    });
+  });
+});


### PR DESCRIPTION
Write unit tests for `extractSearchParams` and `parsePaginationModel` functions