### PR TITLE
Add `CORS` headers to the responses for the client 

### DIFF
--- a/src/router/serveRequests.ts
+++ b/src/router/serveRequests.ts
@@ -6,6 +6,7 @@ import extractResourceName from "./extractResourceName";
 import extractSearchParams from "../utilities/extractSearchParams";
 import extractRequestBody from "../utilities/extractRequestBody";
 import type { Req, RequestHandler, WebSocketHandlers } from "../types/request";
+import crosHeadersSetters from "../utilities/crosHeadersSetters";
 
 export default async function serveRequests(
   request: Request,
@@ -16,6 +17,13 @@ export default async function serveRequests(
   const url = new URL(request.url);
   const path = url.pathname;
   const method = request.method;
+
+  // For the preflight requests by the browsers for CORS policy
+  if (method === "OPTIONS") {
+    const headers = new Headers()
+    crosHeadersSetters(headers)
+    return new Response("{}", { status: 200, headers })
+  }
 
   const requestMethodType = extractResourceName(path) === "ws" ? "WS" : method;
 
@@ -42,6 +50,7 @@ export default async function serveRequests(
         req,
         matchedRoute.handlers as RequestHandler[]
       );
+      res && crosHeadersSetters(res.headers)
       return res;
     }
   }

--- a/src/utilities/crosHeadersSetters.ts
+++ b/src/utilities/crosHeadersSetters.ts
@@ -1,0 +1,5 @@
+export default function crosHeadersSetters(headers: Response["headers"]) {
+    headers.set("Access-Control-Allow-Origin", process.env.CLIENT_ORIGIN);
+    headers.set("Access-Control-Allow-Headers", "Authorization");
+    headers.set("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, PATCH");
+};


### PR DESCRIPTION
Create `crosHeadersSetters` function which takes the headers object of responses and sets the required `CORS` headers for the client(browser) be able to receive the responses confidently without blocking.

Use `crosHeadersSetters` function in `src/router/serveRequests.ts` file to set CORS headers for the responses to the preflight requests that are sent by the browsers to determine if it is safe to fetch this resource, And for the normal responses after handling the requests.